### PR TITLE
fix(benchmark): update benchmark.ipynb so that it is compatible with octreelib@v0.0.5

### DIFF
--- a/notebooks/benchmark.ipynb
+++ b/notebooks/benchmark.ipynb
@@ -10,38 +10,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 5,
    "id": "d009f3b8-3f04-4aac-b10a-4a2e0a34836e",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Jupyter environment detected. Enabling Open3D WebVisualizer.\n",
-      "[Open3D INFO] WebRTC GUI backend enabled.\n",
-      "[Open3D INFO] WebRTCWindowSystem: HTTP handshake server disabled.\n"
-     ]
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-12-20T14:25:22.551281Z",
+     "start_time": "2023-12-20T14:25:21.002067Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "import sys\n",
     "import mrob\n",
     "import time\n",
     "import os\n",
-    "from octreelib.grid import Grid, GridConfig, VisualizationConfig\n",
-    "from octreelib.octree import MultiPoseOctree, OctreeConfig\n",
-    "from typing import Tuple, List\n",
+    "import tqdm\n",
+    "from octreelib.grid import Grid, GridConfig\n",
+    "from typing import Tuple, List, Dict\n",
     "from dataclasses import dataclass\n",
     "import numpy as np\n",
     "import open3d as o3d\n",
     "\n",
     "sys.path.append(\"..\")\n",
     "from slam.backend import BaregBackend, EigenFactorBackend, Backend, BackendOutput\n",
-    "from slam.pipeline import StaticPipeline, StaticPipelineRuntimeParameters\n",
+    "\n",
     "from slam.segmenter import Segmenter, CAPESegmenter, RansacSegmenter\n",
     "from slam.subdivider import Subdivider, CountSubdivider, EigenValueSubdivider, SizeSubdivider\n",
-    "from slam.utils import Reader, HiltiReader, KittiReader"
+    "from slam.utils import DatasetReader, HiltiReader, KittiReader"
    ]
   },
   {
@@ -54,9 +49,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 6,
    "id": "4e183c65-5a53-4152-a1e0-9eeb8afc49de",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-12-20T14:25:23.389009Z",
+     "start_time": "2023-12-20T14:25:23.384258Z"
+    }
+   },
    "outputs": [],
    "source": [
     "SAMPLES_COUNT = 10"
@@ -72,9 +72,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 7,
    "id": "49fcabc0-83d2-4bdb-821e-4f5735930ca1",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-12-20T14:25:24.005440Z",
+     "start_time": "2023-12-20T14:25:23.992233Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def evaluate(timestamps: List[float]):\n",
@@ -90,7 +95,7 @@
     "    timestamps = np.array(timestamps)\n",
     "    print_metrics(timestamps)\n",
     "\n",
-    "def read_patch(reader: Reader,path: str, start: int, end: int) -> List[o3d.geometry.PointCloud]:\n",
+    "def read_patch(reader: DatasetReader,path: str, start: int, end: int) -> List[o3d.geometry.PointCloud]:\n",
     "    \"\"\"\n",
     "    Reads patch of point clouds\n",
     "    \"\"\"\n",
@@ -121,9 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "22088f09-504b-4221-a0df-8bd09ad2a15c",
-   "metadata": {},
+   "execution_count": 8,
    "outputs": [],
    "source": [
     "@dataclass\n",
@@ -147,7 +150,7 @@
     "    distribution: float\n",
     "    segmenters: float\n",
     "    backend: float\n",
-    "\n",
+    "    \n",
     "\n",
     "def run_pipeline(point_clouds: List[o3d.geometry.PointCloud], pipeline: PipelineConfiguration) -> PipelineDurations:\n",
     "    \"\"\"\n",
@@ -159,7 +162,7 @@
     "    initialization_start = time.perf_counter()\n",
     "    pipeline.grid.insert_points(\n",
     "            middle_pose_number,\n",
-    "            point_clouds[middle_pose_number].points,\n",
+    "            np.asarray(point_clouds[middle_pose_number].points),\n",
     "    )\n",
     "    initialization_end = time.perf_counter() - initialization_start\n",
     "    \n",
@@ -171,7 +174,7 @@
     "    for pose_number, point_cloud in enumerate(point_clouds):\n",
     "        if pose_number == middle_pose_number:\n",
     "            continue\n",
-    "        pipeline.grid.insert_points(pose_number, point_cloud.points)\n",
+    "        pipeline.grid.insert_points(pose_number, np.asarray(point_cloud.points))\n",
     "    distribution_end = time.perf_counter() - distribution_start\n",
     "\n",
     "    segmenters_start = time.perf_counter()\n",
@@ -190,7 +193,15 @@
     "        segmenters=segmenters_end,\n",
     "        backend=backend_end,\n",
     "    )"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-12-20T14:25:24.923503Z",
+     "start_time": "2023-12-20T14:25:24.918673Z"
+    }
+   },
+   "id": "1528c7c19e4d9cfe"
   },
   {
    "cell_type": "markdown",
@@ -202,43 +213,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "1156e0c8-d70d-4c12-a9ff-773ca383912b",
+   "execution_count": null,
+   "id": "1eed4317-fa5b-4980-8fae-58263c0b1cfd",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Patch 0 -> 3; Samples count = 10\n",
-      "First point clouds insertion stage\n",
-      "\tmin = 2.647s\n",
-      "\tmax = 2.863s\n",
-      "\tmean = 2.708s\n",
-      "\tstd = 0.066s\n",
-      "Subdividers stage\n",
-      "\tmin = 8.991s\n",
-      "\tmax = 9.287s\n",
-      "\tmean = 9.077s\n",
-      "\tstd = 0.087s\n",
-      "Distribution stage\n",
-      "\tmin = 20.751s\n",
-      "\tmax = 21.297s\n",
-      "\tmean = 20.877s\n",
-      "\tstd = 0.151s\n",
-      "Segmenters stage\n",
-      "\tmin = 7.337s\n",
-      "\tmax = 9.898s\n",
-      "\tmean = 7.762s\n",
-      "\tstd = 0.769s\n",
-      "Backend stage\n",
-      "\tmin = 0.096s\n",
-      "\tmax = 0.155s\n",
-      "\tmean = 0.104s\n",
-      "\tstd = 0.017s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Pipeline configuration\n",
     "# TODO(user): You can manipulate configuration spec below as you want\n",
@@ -274,9 +252,7 @@
     "\n",
     "    grid = Grid(\n",
     "        GridConfig(\n",
-    "            octree_type=MultiPoseOctree,\n",
-    "            octree_config=OctreeConfig(),\n",
-    "            grid_voxel_edge_length=4,\n",
+    "            voxel_edge_length=4,\n",
     "        )\n",
     "    )\n",
     "        \n",
@@ -297,7 +273,7 @@
     "    segmenters_timestamps = []\n",
     "    backend_timestamps = []\n",
     "    \n",
-    "    for sample in range(SAMPLES_COUNT):\n",
+    "    for sample in tqdm.tqdm(range(SAMPLES_COUNT)):\n",
     "        point_clouds = read_patch(dataset_reader, dataset_path, ind, ind + step)\n",
     "        \n",
     "        pipeline_durations = run_pipeline(point_clouds, create_configuration())\n",


### PR DESCRIPTION
`notebooks/benchmark.ipynb` uses deprecated interface of [octreelib](https://github.com/prime-slam/octreelib).
It also uses the class `slam.utils.Reader` which is no longer present in `voxel-slam` and is replaced by `slam.utils.DatasetReader`.

This PR fixes the described incompatibility issues.
