### PR TITLE
feat(yaml_reader): slighlty change yaml configuration

### DIFF
--- a/examples/configurations/hilti.yaml
+++ b/examples/configurations/hilti.yaml
@@ -1,25 +1,25 @@
 dataset:
+  type: "hilti"
   path: "evaluation/hilti"
   patches:
     start: 0
     end: 29
     step: 10
     iterations: 1
-grid:
-  voxel_edge_length: 8
-subdividers:
-  size: 2
-segmenters:
-  ransac:
-    threshold: 0.01
-    initial_points: 6
-    iterations: 5000
-backend:
-  type: "eigen_factor"
-  parameters:
-    iterations_number: 5000
-    robust_type: HUBER
-output:
-  visualization_path: "output/hilti/visualization"
-  optimisation_path: "output/hilti/optimisation"
-debug: true
+pipeline:
+  grid:
+    voxel_edge_length: 8
+  subdividers:
+    size: 1
+  segmenters:
+    ransac:
+      threshold: 0.01
+      initial_points: 6
+      iterations: 1000
+  backend:
+    type: "eigen_factor"
+    parameters:
+      iterations_number: 5000
+      robust_type: QUADRATIC
+  output: "output/hilti"
+debug: false

--- a/examples/configurations/kitti.yaml
+++ b/examples/configurations/kitti.yaml
@@ -1,27 +1,27 @@
 dataset:
+  type: "kitti"
   path: "evaluation/kitti"
   patches:
     start: 0
     end: 100
     step: 10
     iterations: 1
-grid:
-  voxel_edge_length: 16
-subdividers:
-  size: 2
-segmenters:
-  ransac:
-    threshold: 0.01
-    initial_points: 6
-    iterations: 5000
-  cape:
-    correlation: 300
-backend:
-  type: "eigen_factor"
-  parameters:
-    iterations_number: 5000
-    robust_type: HUBER
-output:
-  visualization_path: "output/kitti/visualization"
-  optimisation_path: "output/kitti/optimisation"
+pipeline:
+  grid:
+    voxel_edge_length: 16
+  subdividers:
+    size: 2
+  segmenters:
+    ransac:
+      threshold: 0.01
+      initial_points: 6
+      iterations: 5000
+    cape:
+      correlation: 300
+  backend:
+    type: "eigen_factor"
+    parameters:
+      iterations_number: 5000
+      robust_type: HUBER
+  output: "output/kitti"
 debug: true

--- a/examples/pipeline.py
+++ b/examples/pipeline.py
@@ -46,7 +46,7 @@ from slam.utils import (
 
 
 def prepare_output_directories(
-    configuration: YAMLConfigurationReader
+    configuration: YAMLConfigurationReader,
 ) -> Tuple[str, str]:
     if not os.path.exists(configuration.output_directory):
         os.makedirs(configuration.output_directory)

--- a/examples/pipeline.py
+++ b/examples/pipeline.py
@@ -45,7 +45,9 @@ from slam.utils import (
 )
 
 
-def prepare_output_directories(configuration: YAMLConfigurationReader) -> Tuple[str, str]:
+def prepare_output_directories(
+    configuration: YAMLConfigurationReader
+) -> Tuple[str, str]:
     if not os.path.exists(configuration.output_directory):
         os.makedirs(configuration.output_directory)
 
@@ -162,9 +164,6 @@ if __name__ == "__main__":
 
         for optimised_pose_number in range(start, end):
             posesWriter.write(
-                os.path.join(
-                    poses_dir,
-                    f"{optimised_pose_number}.txt",
-                ),
+                os.path.join(poses_dir, f"{optimised_pose_number}.txt"),
                 poses[optimised_pose_number - start],
             )

--- a/examples/pipeline.py
+++ b/examples/pipeline.py
@@ -19,6 +19,8 @@ How can I run it?
 python3 examples/pipeline.py --configuration_path examples/configurations/hilti.yaml
 ```
 """
+from typing import Tuple
+
 import open3d as o3d
 from octreelib.grid import VisualizationConfig
 
@@ -42,6 +44,23 @@ from slam.utils import (
     OptimisedPoseReadWriter,
 )
 
+
+def prepare_output_directories(configuration: YAMLConfigurationReader) -> Tuple[str, str]:
+    if not os.path.exists(configuration.output_directory):
+        os.makedirs(configuration.output_directory)
+
+    poses_dir = os.path.join(configuration.output_directory, "poses")
+    if not os.path.exists(poses_dir):
+        os.makedirs(poses_dir)
+
+    visualization_dir = os.path.join(configuration.output_directory, "visualization")
+    if configuration.debug:
+        if not os.path.join(visualization_dir):
+            os.makedirs(visualization_dir)
+
+    return poses_dir, visualization_dir
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(prog="Pipeline")
     parser.add_argument("--configuration_path", type=str, required=True)
@@ -50,15 +69,17 @@ if __name__ == "__main__":
     configuration_reader = YAMLConfigurationReader(args.configuration_path)
 
     dataset_reader = DatasetReader
-    if "hilti" in configuration_reader.dataset_path.lower():
+    if "hilti" in configuration_reader.dataset_type.lower():
         dataset_reader = HiltiReader()
-    elif "kitti" in configuration_reader.dataset_path.lower():
+    elif "kitti" in configuration_reader.dataset_type.lower():
         dataset_reader = KittiReader()
-    elif "nuscenes" in configuration_reader.dataset_path.lower():
+    elif "nuscenes" in configuration_reader.dataset_type.lower():
         dataset_reader = NuscenesReader()
     else:
         raise ValueError("Unrecognisable type of dataset")
     posesWriter = OptimisedPoseReadWriter()
+
+    poses_dir, visualization_dir = prepare_output_directories(configuration_reader)
 
     for ind in range(
         configuration_reader.patches_start,
@@ -97,13 +118,14 @@ if __name__ == "__main__":
                 segmenters=configuration_reader.segmenters,
                 filters=configuration_reader.filters,
                 backend=configuration_reader.backend(start, end),
+                debug=configuration_reader.debug,
             )
 
             output = pipeline.run(
                 SequentialPipelineRuntimeParameters(
                     grid_configuration=configuration_reader.grid_configuration,
                     visualization_config=VisualizationConfig(
-                        filepath=f"{configuration_reader.visualization_dir}/{start}-{end - 1}_{iteration_ind}.html"
+                        filepath=f"{visualization_dir}/{start}-{end - 1}_{iteration_ind}.html"
                     ),
                     initial_point_cloud_number=(end - start) // 2,
                 )
@@ -141,7 +163,7 @@ if __name__ == "__main__":
         for optimised_pose_number in range(start, end):
             posesWriter.write(
                 os.path.join(
-                    configuration_reader.optimisation_dir,
+                    poses_dir,
                     f"{optimised_pose_number}.txt",
                 ),
                 poses[optimised_pose_number - start],

--- a/slam/backend/mrob_backend.py
+++ b/slam/backend/mrob_backend.py
@@ -25,10 +25,7 @@ class MROBBackend(Backend):
     """
 
     def __init__(
-        self,
-        poses_number: int,
-        iterations_number: int,
-        robust_type: int = mrob.HUBER,
+        self, poses_number: int, iterations_number: int, robust_type: int = mrob.HUBER
     ) -> None:
         self._graph: mrob.FGraph = mrob.FGraph(robust_type)
         self._poses_number: int = poses_number
@@ -72,9 +69,7 @@ class MROBBackend(Backend):
         """
         self._init_poses()
         self._init_point_clouds(grid)
-        metrics = [
-            Metric(name="FGraph initial error", value=self._graph.chi2(True)),
-        ]
+        metrics = [Metric(name="FGraph initial error", value=self._graph.chi2(True))]
         converge_iterations = self._graph.solve(mrob.LM_ELLIPS, self._iterations_number)
         while converge_iterations == 0:
             print("Optimization didn't converge")
@@ -82,17 +77,11 @@ class MROBBackend(Backend):
                 mrob.LM_ELLIPS, self._iterations_number
             )
 
-        metrics.append(
-            Metric(name="Iterations to converge", value=converge_iterations),
-        )
-        metrics.append(
-            Metric(name="chi2", value=self._graph.chi2()),
-        )
+        metrics.append(Metric(name="Iterations to converge", value=converge_iterations))
+        metrics.append(Metric(name="chi2", value=self._graph.chi2()))
 
         return BackendOutput(
-            self._graph.get_estimated_state(),
-            metrics,
-            self.__get_unused_features(),
+            self._graph.get_estimated_state(), metrics, self.__get_unused_features()
         )
 
     def __get_unused_features(self) -> List[int]:
@@ -107,6 +96,7 @@ class MROBBackend(Backend):
         try:
             robust_mask = self._graph.get_eigen_factors_robust_mask()
         except AttributeError:
+            print("[WARNING] Most likely you are not using robust optimisations")
             return []
 
         unused_features = []

--- a/slam/backend/mrob_backend.py
+++ b/slam/backend/mrob_backend.py
@@ -25,7 +25,10 @@ class MROBBackend(Backend):
     """
 
     def __init__(
-        self, poses_number: int, iterations_number: int, robust_type: int = mrob.HUBER
+        self,
+        poses_number: int,
+        iterations_number: int,
+        robust_type: int = mrob.HUBER
     ) -> None:
         self._graph: mrob.FGraph = mrob.FGraph(robust_type)
         self._poses_number: int = poses_number
@@ -69,7 +72,9 @@ class MROBBackend(Backend):
         """
         self._init_poses()
         self._init_point_clouds(grid)
-        metrics = [Metric(name="FGraph initial error", value=self._graph.chi2(True))]
+        metrics = [
+            Metric(name="FGraph initial error", value=self._graph.chi2(True))
+        ]
         converge_iterations = self._graph.solve(mrob.LM_ELLIPS, self._iterations_number)
         while converge_iterations == 0:
             print("Optimization didn't converge")
@@ -77,11 +82,17 @@ class MROBBackend(Backend):
                 mrob.LM_ELLIPS, self._iterations_number
             )
 
-        metrics.append(Metric(name="Iterations to converge", value=converge_iterations))
-        metrics.append(Metric(name="chi2", value=self._graph.chi2()))
+        metrics.append(
+            Metric(name="Iterations to converge", value=converge_iterations)
+        )
+        metrics.append(
+            Metric(name="chi2", value=self._graph.chi2())
+        )
 
         return BackendOutput(
-            self._graph.get_estimated_state(), metrics, self.__get_unused_features()
+            self._graph.get_estimated_state(),
+            metrics,
+            self.__get_unused_features()
         )
 
     def __get_unused_features(self) -> List[int]:

--- a/slam/backend/mrob_backend.py
+++ b/slam/backend/mrob_backend.py
@@ -25,10 +25,7 @@ class MROBBackend(Backend):
     """
 
     def __init__(
-        self,
-        poses_number: int,
-        iterations_number: int,
-        robust_type: int = mrob.HUBER
+        self, poses_number: int, iterations_number: int, robust_type: int = mrob.HUBER
     ) -> None:
         self._graph: mrob.FGraph = mrob.FGraph(robust_type)
         self._poses_number: int = poses_number
@@ -72,9 +69,7 @@ class MROBBackend(Backend):
         """
         self._init_poses()
         self._init_point_clouds(grid)
-        metrics = [
-            Metric(name="FGraph initial error", value=self._graph.chi2(True))
-        ]
+        metrics = [Metric(name="FGraph initial error", value=self._graph.chi2(True))]
         converge_iterations = self._graph.solve(mrob.LM_ELLIPS, self._iterations_number)
         while converge_iterations == 0:
             print("Optimization didn't converge")
@@ -82,17 +77,11 @@ class MROBBackend(Backend):
                 mrob.LM_ELLIPS, self._iterations_number
             )
 
-        metrics.append(
-            Metric(name="Iterations to converge", value=converge_iterations)
-        )
-        metrics.append(
-            Metric(name="chi2", value=self._graph.chi2())
-        )
+        metrics.append(Metric(name="Iterations to converge", value=converge_iterations))
+        metrics.append(Metric(name="chi2", value=self._graph.chi2()))
 
         return BackendOutput(
-            self._graph.get_estimated_state(),
-            metrics,
-            self.__get_unused_features()
+            self._graph.get_estimated_state(), metrics, self.__get_unused_features()
         )
 
     def __get_unused_features(self) -> List[int]:

--- a/slam/pipeline/configuration/reader.py
+++ b/slam/pipeline/configuration/reader.py
@@ -63,6 +63,24 @@ class ConfigurationReader(ABC):
         return bool(value)
 
     @property
+    def dataset_type(self) -> str:
+        """
+        Represents dataset type for pose and clouds reading
+
+        Returns
+        -------
+        dataset_type: str
+            Dataset type
+        """
+        try:
+            dataset_configuration = copy.deepcopy(self._configuration["dataset"])
+            value = dataset_configuration["type"]
+        except KeyError as e:
+            raise ValueError(f"{e} must be set")
+
+        return value
+
+    @property
     def dataset_path(self) -> str:
         """
         Represents dataset path parameter of pipeline
@@ -157,38 +175,20 @@ class ConfigurationReader(ABC):
         return int(value)
 
     @property
-    def visualization_dir(self) -> str:
+    def output_directory(self) -> str:
         """
-        Represents visualization directory parameter of pipeline
+        Represents output directory which contains all products of voxel-based pipeline
 
         Returns
         -------
-        visualization_dir: str
-            Path to visualisation directory to save
+        output_directory: str
+            Path to output directory
         """
         try:
-            output_configuration = copy.deepcopy(self._configuration["output"])
-            value = output_configuration["visualization_path"]
+            pipeline_configuration = copy.deepcopy(self._configuration["pipeline"])
+            value = pipeline_configuration["output"]
         except KeyError:
-            return "output/visualization"
-
-        return value
-
-    @property
-    def optimisation_dir(self) -> str:
-        """
-        Represents optimisation directory parameter of pipeline
-
-        Returns
-        -------
-        optimisation_dir: str
-            Path to optimisation poses directory to save
-        """
-        try:
-            output_configuration = copy.deepcopy(self._configuration["output"])
-            value = output_configuration["optimisation_path"]
-        except KeyError:
-            return "output/optimisation"
+            return "output"
 
         return value
 
@@ -203,9 +203,8 @@ class ConfigurationReader(ABC):
             Subdividers list
         """
         try:
-            subdividers_configuration = copy.deepcopy(
-                self._configuration["subdividers"]
-            )
+            pipeline_configuration = copy.deepcopy(self._configuration["pipeline"])
+            subdividers_configuration = pipeline_configuration["subdividers"]
         except KeyError:
             raise ValueError("subdividers must be not empty")
 
@@ -218,9 +217,7 @@ class ConfigurationReader(ABC):
 
         for name in subdividers_configuration.keys():
             name = name.lower()
-            subdividers.append(
-                subdividers_names[name](subdividers_configuration[name]),
-            )
+            subdividers.append(subdividers_names[name](subdividers_configuration[name]))
 
         return subdividers
 
@@ -247,7 +244,8 @@ class ConfigurationReader(ABC):
             Segmenters list
         """
         try:
-            segmenters_configuration = copy.deepcopy(self._configuration["segmenters"])
+            pipeline_configuration = copy.deepcopy(self._configuration["pipeline"])
+            segmenters_configuration = pipeline_configuration["segmenters"]
         except KeyError:
             raise ValueError("segmenters must be not empty")
 
@@ -277,7 +275,8 @@ class ConfigurationReader(ABC):
             Grid configuration
         """
         try:
-            grid_configuration = copy.deepcopy(self._configuration["grid"])
+            pipeline_configuration = copy.deepcopy(self._configuration["pipeline"])
+            grid_configuration = pipeline_configuration["grid"]
         except KeyError:
             raise ValueError("grid_configuration must be not empty")
 
@@ -300,14 +299,12 @@ class ConfigurationReader(ABC):
             Backend of pipeline
         """
         try:
-            backend_configuration = copy.deepcopy(self._configuration["backend"])
+            pipeline_configuration = copy.deepcopy(self._configuration["pipeline"])
+            backend_configuration = pipeline_configuration["backend"]
         except KeyError:
             raise ValueError("backend_configuration must be not empty")
 
-        backend_names = {
-            "eigen_factor": EigenFactorBackend,
-            "bareg": BaregBackend,
-        }
+        backend_names = {"eigen_factor": EigenFactorBackend, "bareg": BaregBackend}
         robust_types = {
             "huber": mrob.HUBER,
             "quadratic": mrob.QUADRATIC,

--- a/slam/pipeline/pipeline.py
+++ b/slam/pipeline/pipeline.py
@@ -51,6 +51,8 @@ class Pipeline(ABC):
         Filter conditions to filter voxels in grid
     backend: Backend
         Backend of SLAM algorithm that optimises given poses
+    debug: bool
+        Represents debug parameter. If it is specified, the pipeline will save the visualization files.
     """
 
     def __init__(
@@ -61,6 +63,7 @@ class Pipeline(ABC):
         segmenters: List[Segmenter],
         filters: List[Filter],
         backend: Backend,
+        debug: bool,
     ) -> None:
         if len(point_clouds) != len(poses):
             raise ValueError("Sizes of point_cloud and poses arrays must be equal")
@@ -71,6 +74,7 @@ class Pipeline(ABC):
         self._segmenters: List[Segmenter] = segmenters
         self._filters: List[Filter] = filters
         self._backend: Backend = backend
+        self._debug: bool = debug
 
     @abstractmethod
     def run(self, parameters: PipelineRuntimeParameters) -> BackendOutput:

--- a/slam/pipeline/sequential_pipeline.py
+++ b/slam/pipeline/sequential_pipeline.py
@@ -66,7 +66,10 @@ class SequentialPipeline(Pipeline):
 
         backend_output = self._backend.process(grid)
 
-        parameters.visualization_config.unused_voxels = backend_output.unused_features
-        grid.visualize(parameters.visualization_config)
+        if self._debug:
+            parameters.visualization_config.unused_voxels = (
+                backend_output.unused_features
+            )
+            grid.visualize(parameters.visualization_config)
 
         return backend_output

--- a/slam/utils/__init__.py
+++ b/slam/utils/__init__.py
@@ -1,4 +1,3 @@
-import slam.pipeline.configuration as configuration_module
 import slam.utils.pose_readwriter as pose_readwriter_module
 from slam.utils.dataset_reader import (
     DatasetReader,

--- a/slam/utils/__init__.py
+++ b/slam/utils/__init__.py
@@ -7,6 +7,5 @@ from slam.utils.dataset_reader import (
 )
 from slam.utils.pose_readwriter import *
 
-__all__ = (configuration_module.__all__
-           + pose_readwriter_module.__all__ +
+__all__ = (pose_readwriter_module.__all__ +
            ["DatasetReader", "HiltiReader", "KittiReader", "NuscenesReader"])

--- a/tests/data/yaml_configurations/correct_configuration.yaml
+++ b/tests/data/yaml_configurations/correct_configuration.yaml
@@ -1,24 +1,24 @@
 dataset:
+  type: "dataset_type"
   path: "path/to/dataset"
   patches:
     start: 0
     end: 100
     step: 10
     iterations: 1
-grid:
-  voxel_edge_length: 8
-subdividers:
-  size: 2
-segmenters:
-  ransac:
-    threshold: 0.01
-    initial_points: 6
-    iterations: 5000
-backend:
-  type: "eigen_factor"
-  parameters:
-    iterations_number: 5000
-    robust_type: HUBER
-output:
-  visualization_path: "output"
-  optimisation_path: "output"
+pipeline:
+  grid:
+    voxel_edge_length: 8
+  subdividers:
+    size: 2
+  segmenters:
+    ransac:
+      threshold: 0.01
+      initial_points: 6
+      iterations: 5000
+  backend:
+    type: "eigen_factor"
+    parameters:
+      iterations_number: 5000
+      robust_type: HUBER
+  output: "output"

--- a/tests/data/yaml_configurations/incorrect_configuration_dataset.yaml
+++ b/tests/data/yaml_configurations/incorrect_configuration_dataset.yaml
@@ -1,17 +1,16 @@
-grid:
-  voxel_edge_length: 8
-subdividers:
-  size: 2
-segmenters:
-  ransac:
-    threshold: 0.01
-    initial_points: 6
-    iterations: 5000
-backend:
-  type: "eigen_factor"
-  parameters:
-    iterations_number: 5000
-    robust_type: HUBER
-output:
-  visualization_path: "output"
-  optimisation_path: "output"
+pipeline:
+  grid:
+    voxel_edge_length: 8
+  subdividers:
+    size: 2
+  segmenters:
+    ransac:
+      threshold: 0.01
+      initial_points: 6
+      iterations: 5000
+  backend:
+    type: "eigen_factor"
+    parameters:
+      iterations_number: 5000
+      robust_type: HUBER
+  output: "output"

--- a/tests/data/yaml_configurations/incorrect_configuration_dataset_type.yaml
+++ b/tests/data/yaml_configurations/incorrect_configuration_dataset_type.yaml
@@ -1,5 +1,4 @@
 dataset:
-  type: "dataset_type"
   path: "path/to/dataset"
   patches:
     start: 0
@@ -16,4 +15,9 @@ pipeline:
       threshold: 0.01
       initial_points: 6
       iterations: 5000
+  backend:
+    type: "eigen_factor"
+    parameters:
+      iterations_number: 5000
+      robust_type: HUBER
   output: "output"

--- a/tests/data/yaml_configurations/incorrect_configuration_patches.yaml
+++ b/tests/data/yaml_configurations/incorrect_configuration_patches.yaml
@@ -1,19 +1,19 @@
 dataset:
+  type: "dataset_type"
   path: "path/to/dataset"
-grid:
-  voxel_edge_length: 8
-subdividers:
-  size: 2
-segmenters:
-  ransac:
-    threshold: 0.01
-    initial_points: 6
-    iterations: 5000
-backend:
-  type: "eigen_factor"
-  parameters:
-    iterations_number: 5000
-    robust_type: HUBER
-output:
-  visualization_path: "output"
-  optimisation_path: "output"
+pipeline:
+  grid:
+    voxel_edge_length: 8
+  subdividers:
+    size: 2
+  segmenters:
+    ransac:
+      threshold: 0.01
+      initial_points: 6
+      iterations: 5000
+  backend:
+    type: "eigen_factor"
+    parameters:
+      iterations_number: 5000
+      robust_type: HUBER
+  output: "output"

--- a/tests/data/yaml_configurations/incorrect_configuration_segmenters.yaml
+++ b/tests/data/yaml_configurations/incorrect_configuration_segmenters.yaml
@@ -1,19 +1,19 @@
 dataset:
+  type: "dataset_type"
   path: "path/to/dataset"
   patches:
     start: 0
     end: 100
     step: 10
     iterations: 1
-grid:
-  voxel_edge_length: 8
-subdividers:
-  size: 2
-backend:
-  type: "eigen_factor"
-  parameters:
-    iterations_number: 5000
-    robust_type: HUBER
-output:
-  visualization_path: "output"
-  optimisation_path: "output"
+pipeline:
+  grid:
+    voxel_edge_length: 8
+  subdividers:
+    size: 2
+  backend:
+    type: "eigen_factor"
+    parameters:
+      iterations_number: 5000
+      robust_type: HUBER
+  output: "output"

--- a/tests/data/yaml_configurations/incorrect_configuration_subdividers.yaml
+++ b/tests/data/yaml_configurations/incorrect_configuration_subdividers.yaml
@@ -1,22 +1,22 @@
 dataset:
+  type: "dataset_type"
   path: "path/to/dataset"
   patches:
     start: 0
     end: 100
     step: 10
     iterations: 1
-grid:
-  voxel_edge_length: 8
-segmenters:
-  ransac:
-    threshold: 0.01
-    initial_points: 6
-    iterations: 5000
-backend:
-  type: "eigen_factor"
-  parameters:
-    iterations_number: 5000
-    robust_type: HUBER
-output:
-  visualization_path: "output"
-  optimisation_path: "output"
+pipeline:
+  grid:
+    voxel_edge_length: 8
+  segmenters:
+    ransac:
+      threshold: 0.01
+      initial_points: 6
+      iterations: 5000
+  backend:
+    type: "eigen_factor"
+    parameters:
+      iterations_number: 5000
+      robust_type: HUBER
+  output: "output"

--- a/tests/test_sequential_pipeline.py
+++ b/tests/test_sequential_pipeline.py
@@ -16,7 +16,7 @@ from slam.typing import ArrayNx3, ArrayNx4x4
 
 
 @pytest.mark.parametrize(
-    "points," "poses," "subdividers," "filters," "segmenters," "backend,",
+    "points," "poses," "subdividers," "filters," "segmenters," "backend," "debug,",
     [
         (
             np.array(
@@ -32,6 +32,7 @@ from slam.typing import ArrayNx3, ArrayNx4x4
             EigenFactorBackend(
                 poses_number=1, iterations_number=1, robust_type=mrob.HUBER
             ),
+            False,
         ),
     ],
 )
@@ -42,6 +43,7 @@ def test_sequential_pipeline(
     filters: List[Filter],
     segmenters: List[Segmenter],
     backend: Backend,
+    debug: bool,
 ):
     sequential_pipeline = SequentialPipeline(
         point_clouds=[o3d.geometry.PointCloud(o3d.utility.Vector3dVector(points))],
@@ -50,6 +52,7 @@ def test_sequential_pipeline(
         segmenters=segmenters,
         filters=filters,
         backend=backend,
+        debug=debug,
     )
     output = sequential_pipeline.run(
         SequentialPipelineRuntimeParameters(

--- a/tests/test_yaml_configuration_reader.py
+++ b/tests/test_yaml_configuration_reader.py
@@ -14,13 +14,13 @@ from slam.subdivider import SizeSubdivider, Subdivider
 @pytest.mark.parametrize(
     "yaml_configuration_path, "
     "debug, "
+    "dataset_type, "
     "dataset_path, "
     "patches_start, "
     "patches_end, "
     "patches_step, "
     "patches_iterations, "
-    "visualization_dir, "
-    "optimisation_dir, "
+    "output_directory, "
     "subdividers, "
     "filters, "
     "segmenters, "
@@ -30,12 +30,12 @@ from slam.subdivider import SizeSubdivider, Subdivider
         (
             "tests/data/yaml_configurations/correct_configuration.yaml",
             False,
+            "dataset_type",
             "path/to/dataset",
             0,
             100,
             10,
             1,
-            "output",
             "output",
             [SizeSubdivider(size=2)],
             [],
@@ -50,13 +50,13 @@ from slam.subdivider import SizeSubdivider, Subdivider
 def test_correct_configuration(
     yaml_configuration_path: str,
     debug: bool,
+    dataset_type: bool,
     dataset_path: str,
     patches_start: int,
     patches_end: int,
     patches_step: int,
     patches_iterations: int,
-    visualization_dir: str,
-    optimisation_dir: str,
+    output_directory: str,
     subdividers: List[Subdivider],
     filters: List[Filter],
     segmenters: List[Segmenter],
@@ -71,6 +71,7 @@ def test_correct_configuration(
     assert patches_end == yaml_reader.patches_end
     assert patches_step == yaml_reader.patches_step
     assert patches_iterations == yaml_reader.patches_iterations
+    assert output_directory == yaml_reader.output_directory
     assert len(subdividers) == len(yaml_reader.subdividers)
     assert len(filters) == len(yaml_reader.filters)
     assert len(segmenters) == len(yaml_reader.segmenters)
@@ -106,6 +107,10 @@ def test_correct_configuration(
             "tests/data/yaml_configurations/incorrect_configuration_subdividers.yaml",
             "subdividers",
         ),
+        (
+            "tests/data/yaml_configurations/incorrect_configuration_dataset_type.yaml",
+            "type",
+        ),
     ],
 )
 def test_incorrect_yaml_configuration_reader(
@@ -116,13 +121,13 @@ def test_incorrect_yaml_configuration_reader(
 
     with pytest.raises(ValueError) as excinfo:
         _ = yaml_reader.debug
+        _ = yaml_reader.dataset_type
         _ = yaml_reader.dataset_path
         _ = yaml_reader.patches_start
         _ = yaml_reader.patches_end
         _ = yaml_reader.patches_step
         _ = yaml_reader.patches_iterations
-        _ = yaml_reader.visualization_dir
-        _ = yaml_reader.optimisation_dir
+        _ = yaml_reader.output_directory
         _ = yaml_reader.subdividers
         _ = yaml_reader.filters
         _ = yaml_reader.segmenters


### PR DESCRIPTION
- `dataset.type` parameter was added to chose dataset reader. It was obviously bad decision do it based on the path to the dataset
- `grid`, `segmenters`, `subdividers`, etc. parameters were moved to pipeline section 
- `visualization_dir` and `optimisation_dir` were deleted. `output_directory` parameter replaced there, now `output/poses` and `output/optimisation` directories will be created automatically